### PR TITLE
Workardound for GH Issue 1857.

### DIFF
--- a/www/index.js
+++ b/www/index.js
@@ -53,8 +53,18 @@ function startScreenSharing() {
 
     twilioRoom.localParticipant.publishTrack(screenTrack).then(function(publication) {
         console.log('The LocalTrack "' + publication.trackName + '" was successfully published.');
+        shimTrackCloneSettings(screenTrack);
     }).catch(error => {
         console.log('Screen sharing track error:', error);
+    });
+}
+
+function shimTrackCloneSettings(localVideoTrack) {
+    localVideoTrack._trackSender._clones.forEach(function(trackSender) {
+        const track = trackSender.track;
+        const initialSettings = track.getSettings();
+        const actualGetSettings = track.getSettings.bind(track);
+        track.getSettings = function() { return Object.assign({}, initialSettings, actualGetSettings()); };
     });
 }
 


### PR DESCRIPTION
@PavloShchur ,

This is a temporary workaround for twilio/twilio-video.js#1857. For some reason, the `width` and `height` properties in `screenTrack.mediaStreamTrack.getSettings()` is removed after a little while. This causes our Adaptive Simulcast feature (`preferredVideoCodecs: 'auto'`) to throw an "object is undefined" error, which is converted to the error you see in the console. Can you try this workaround to see if it fixes your issue? In the meantime, we will work on fixing the bug in the SDK.